### PR TITLE
Add initial support for battery charge status

### DIFF
--- a/audiapi/Services.py
+++ b/audiapi/Services.py
@@ -7,6 +7,7 @@ from audiapi.model.HonkFlash import HonkFlashAction, RemoteHonkFlashActionStatus
 from audiapi.model.RequestStatus import RequestStatus
 from audiapi.model.Vehicle import VehiclesResponse, Vehicle
 from audiapi.model.VehicleDataResponse import VehicleDataResponse
+from audiapi.model.BatteryChargeResponse import BatteryChargeResponse
 
 
 class Service(metaclass=ABCMeta):
@@ -313,10 +314,23 @@ class PushNotificationService(Service):
         return 'fns/subscription/v1'
 
 
-class RemoteBatteryChargeService(Service):
+class RemoteBatteryChargeService(VehicleService):
     """
-    For EV only - timer for choosing when the battery should be charged
+    For EV only - battery status and charge management
     """
+
+    def get_status(self):
+        """
+        Returns battery charge status
+
+        :return: BatteryChargeResponse
+        :rtype: BatteryChargeResponse
+        """
+
+        data = self._api.get(self.url('/vehicles/{vin}/charger'))
+        response = BatteryChargeResponse()
+        response.parse(data)
+        return response
 
     def _get_path(self):
         return 'bs/batterycharge/v1'

--- a/audiapi/model/BatteryChargeResponse.py
+++ b/audiapi/model/BatteryChargeResponse.py
@@ -1,0 +1,10 @@
+class BatteryChargeResponse:
+    """
+    Represents a battery charge response
+    """
+
+    def parse(self, data):
+        self.charger = data.get('charger')
+
+    def __str__(self):
+        return str(self.__dict__)


### PR DESCRIPTION
Would be happy to provide better status response modeling. Fix #8.

This is the JSON I'm seeing:

```
{
    "charger": {
        "settings": {
            "maxChargeCurrent": {
                "content": 32,
                "timestamp": "2019-12-05T09:47:00Z"
            },
            "chargeModeSelection": {
                "modificationState": {
                    "content": "canNotBeModified",
                    "timestamp": "2019-12-05T09:47:00Z"
                },
                "modificationReason": {
                    "content": "systemOff",
                    "timestamp": "2019-12-05T09:47:00Z"
                },
                "value": {
                    "content": "immediateCharging",
                    "timestamp": "2019-12-05T09:47:00Z"
                }
            }
        },
        "status": {
            "chargingStatusData": {
                "chargingMode": {
                    "content": "off",
                    "timestamp": "2019-12-05T09:47:02Z"
                },
                "chargingStateErrorCode": {
                    "content": 0,
                    "timestamp": "2019-12-05T09:47:02Z"
                },
                "chargingReason": {
                    "content": "invalid",
                    "timestamp": "2019-12-05T09:47:02Z"
                },
                "externalPowerSupplyState": {
                    "content": "unavailable",
                    "timestamp": "2019-12-05T09:47:02Z"
                },
                "energyFlow": {
                    "content": "off",
                    "timestamp": "2019-12-05T09:47:02Z"
                },
                "chargingState": {
                    "content": "off",
                    "timestamp": "2019-12-05T09:47:02Z"
                }
            },
            "cruisingRangeStatusData": {
                "engineTypeFirstEngine": {
                    "content": "petrolGasoline",
                    "timestamp": "2019-12-05T11:20:11Z"
                },
                "primaryEngineRange": {
                    "content": 120,
                    "timestamp": "2019-12-05T11:20:11Z"
                },
                "hybridRange": {
                    "content": 120,
                    "timestamp": "2019-12-05T11:20:11Z"
                },
                "engineTypeSecondEngine": {
                    "content": "typeIsElectric",
                    "timestamp": "2019-12-05T11:20:11Z"
                },
                "secondaryEngineRange": {
                    "content": 0,
                    "timestamp": "2019-12-05T11:20:11Z"
                }
            },
            "ledStatusData": {
                "ledColor": {
                    "content": "none",
                    "timestamp": "2019-12-05T09:47:02Z"
                },
                "ledState": {
                    "content": "off",
                    "timestamp": "2019-12-05T09:47:02Z"
                }
            },
            "batteryStatusData": {
                "stateOfCharge": {
                    "content": 0,
                    "timestamp": "2019-12-05T11:20:11Z"
                },
                "remainingChargingTime": {
                    "content": 65535,
                    "timestamp": "2019-12-05T09:47:02Z"
                },
                "remainingChargingTimeTargetSOC": {
                    "content": "maxSOC",
                    "timestamp": "2019-12-05T09:47:02Z"
                }
            },
            "plugStatusData": {
                "plugState": {
                    "content": "disconnected",
                    "timestamp": "2019-12-05T09:47:02Z"
                },
                "lockState": {
                    "content": "unlocked",
                    "timestamp": "2019-12-05T09:47:02Z"
                }
            }
        }
    }
}
```